### PR TITLE
add Subject Alt Name support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,3 +10,10 @@ default['x509']['city'] = 'London'
 default['x509']['organization'] = 'Example Ltd'
 default['x509']['department'] = 'Certificate Automation'
 default['x509']['email'] = 'x509-auto@example.com'
+
+default['x509']['tls_root'] = case node['platform_family']
+when 'rhel'
+  '/etc/pki/tls'
+else
+  '/etc/ssl'
+end

--- a/client-gem/chef-ssl-client.gemspec
+++ b/client-gem/chef-ssl-client.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "chef",          ">= 0.10.0"
   s.add_dependency "spice",         "= 1.0.4"   # >= 1.0.6 brings breaking changes
-  s.add_dependency "eassl2",        "~> 2.0.1"
+  s.add_dependency "eassl3",        "~> 3.0.1"
   s.add_dependency "highline",      ">= 1.6.15" # < .15 apparently buggy
   s.add_dependency "commander",     "~> 4.1.0"
   s.add_dependency "multi_json",    ">= 1.0.0"

--- a/client-gem/lib/chef-ssl/client/request.rb
+++ b/client-gem/lib/chef-ssl/client/request.rb
@@ -29,10 +29,10 @@ module ChefSSL
         IssuedCertificate.new(self, cert)
       end
 
-      def self.create(key, type, options)
-        name = EaSSL::CertificateName.new(options)
-        csr  = EaSSL::SigningRequest.new(:name => name, :key => key)
-        self.new('localhost', { 'type' => type }, csr)
+      def self.create(options)
+        name = EaSSL::CertificateName.new(options[:name])
+        csr  = EaSSL::SigningRequest.new(options.update({ :name => name }))
+        self.new('localhost', { 'type' => options[:type] || 'server' }, csr)
       end
     end
   end

--- a/client-gem/lib/chef-ssl/client/version.rb
+++ b/client-gem/lib/chef-ssl/client/version.rb
@@ -1,5 +1,5 @@
 module ChefSSL
   class Client
-    VERSION = '1.2.0'
+    VERSION = '1.2.1'
   end
 end

--- a/client-gem/lib/chef-ssl/command.rb
+++ b/client-gem/lib/chef-ssl/command.rb
@@ -40,8 +40,6 @@ command :issue do |c|
     unless options.type == 'server' || options.type == 'client'
       raise "type must be server or client"
     end
-    
-    client = ChefSSL::Client.new
 
     authority = ChefSSL::Client.load_authority(
       :password => ask("Enter CA passphrase:  ") { |q| q.echo = false },
@@ -61,7 +59,7 @@ command :issue do |c|
       :email => h['emailAddress']
     }
 
-    req = ChefSSL::Client::Request.create(key, options.type, name)
+    req = ChefSSL::Client::Request.create(options.__hash__.update({ :key => key, :name => name }))
     cert = authority.sign(req)
 
     if options.save

--- a/client-gem/spec/request_spec.rb
+++ b/client-gem/spec/request_spec.rb
@@ -84,7 +84,7 @@ EOCERT
     name = {
       :common_name => 'cn'
     }
-    req = ChefSSL::Client::Request.create(key, 'server', name)
+    req = ChefSSL::Client::Request.create({ :name => name, :key => key, :type => 'server'})
     req.class.should == ChefSSL::Client::Request
   end
 

--- a/libraries/x509.rb
+++ b/libraries/x509.rb
@@ -12,9 +12,9 @@ def x509_load_key(path)
   return EaSSL::Key.load(path)
 end
 
-def x509_generate_csr(key, name)
-  ea_name = EaSSL::CertificateName.new(name)
-  ea_csr  = EaSSL::SigningRequest.new(:name => ea_name, :key => key)
+def x509_generate_csr(info)
+  ea_name = EaSSL::CertificateName.new(info[:name])
+  ea_csr  = EaSSL::SigningRequest.new(info.merge({:name => ea_name}))
   ea_csr
 end
 
@@ -75,5 +75,5 @@ end
 #for a caname in the certificate_revocation_list data bag, return the path to the file
 def x509_get_crl_path(caname) 
   item = x509_get_crl(caname)
-  return "/etc/ssl/certs/#{item['hash']}.r0"  
+  return ::File.join(node['x509']['tls_root'], 'certs', "#{item['hash']}}.r0")
 end

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -90,16 +90,19 @@ action :create do
         end
 
         # Generate the new CSR using the existing key
-        csr = x509_generate_csr(
-          key,
-          :common_name => new_resource.cn || new_resource.name,
-          :city => node['x509']['city'],
-          :state => node['x509']['state'],
-          :email => node['x509']['email'],
-          :country => node['x509']['country'],
-          :department => node['x509']['department'],
-          :organization => node['x509']['organization']
-        )
+        csr = x509_generate_csr({
+          :key => key,
+          :name => {
+            :common_name => new_resource.cn || new_resource.name,
+            :city => node['x509']['city'],
+            :state => node['x509']['state'],
+            :email => node['x509']['email'],
+            :country => node['x509']['country'],
+            :department => node['x509']['department'],
+            :organization => node['x509']['organization']
+          },
+          :subject_alt_name => new_resource.subject_alt_name
+        })
         cert = nil
       else
         # Generate and encrypt the private key with the public key of
@@ -114,15 +117,19 @@ action :create do
 
         # Generate the CSR, and sign it with a scratch CA to create a
         # temporary certificate.
-        csr = x509_generate_csr(key,
-          :common_name => new_resource.cn || new_resource.name,
-          :city => node['x509']['city'],
-          :state => node['x509']['state'],
-          :email => node['x509']['email'],
-          :country => node['x509']['country'],
-          :department => node['x509']['department'],
-          :organization => node['x509']['organization']
-        )
+        csr = x509_generate_csr({
+          :key => key,
+          :name => {
+            :common_name => new_resource.cn || new_resource.name,
+            :city => node['x509']['city'],
+            :state => node['x509']['state'],
+            :email => node['x509']['email'],
+            :country => node['x509']['country'],
+            :department => node['x509']['department'],
+            :organization => node['x509']['organization']
+          },
+          :subject_alt_name => new_resource.subject_alt_name
+        })
         cert, ca = x509_issue_self_signed_cert(
           csr,
           new_resource.type,
@@ -132,7 +139,7 @@ action :create do
           :country => node['x509']['country'],
           :department => node['x509']['department'],
           :organization => node['x509']['organization']
-        )
+          )
       end
 
       node.set['csr_outbox'][new_resource.name] = {

--- a/providers/crl.rb
+++ b/providers/crl.rb
@@ -3,7 +3,7 @@ action :create do
   if not new_resource.filename.nil?
     crl_file = new_resource.filename
   else
-    crl_file = "/etc/ssl/certs/#{item['hash']}.r0"
+    crl_file = ::File.join(node['x509']['tls_root'], 'certs', "#{item['hash']}}.r0")
   end
   Chef::Log.info("MDH: filename: #{crl_file}")
   new_resource.filename = crl_file

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,7 +22,7 @@ if node['x509']['key_vault']
   include_recipe "vt-gpg"
 end
 
-chef_gem "eassl2" do
+chef_gem "eassl3" do
   action :nothing
 end.run_action(:upgrade)
 

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -11,6 +11,7 @@ attribute :ca,   :kind_of => String, :required => true
 attribute :type, :kind_of => String, :default => 'server', :equal_to => ['server', 'client']
 attribute :bits, :kind_of => Fixnum, :default => 2048, :equal_to => [1024, 2048, 4096, 8192]
 attribute :days, :kind_of => Fixnum, :default => (365 * 5)
+attribute :subject_alt_name, :kind_of => Array, :default => Array.new
 
 attribute :owner, :kind_of => String, :default => 'root'
 attribute :group, :kind_of => String, :default => 'root'


### PR DESCRIPTION
Uses a new version of the EaSSL gem that I forked since the original maintainer was the same as the original cookbook maintainer who was unresponsive.  Allows for specifying an array of DNS names to add to the certificate request and the chef-ssl client now recognizes extensions and includes them in the generated certificate.

Also added support for the default cert/private directories on rhel.  I probably should have separated that into its own pull request but the change is small so I didn't put in the extra work to do so.
