### PR TITLE
subjectAltName support redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ Webserver SSL certificate specifying key size and validity period:
       days 365
     end
 
+
+Webserver SSL certificate with subject alt names:
+
+    x509_certificate "www.example.com" do
+      ca "MyCA"
+      key "/etc/ssl/www.example.com.key"
+      certificate "/etc/ssl/www.example.com.cert"
+      bits 1024
+      days 365
+      subject_alt_name ["www.example.com", "example.com"]
+    end
+
 REST API Server Certificate, with CA Certificate:
 
     x509_certificate "service.example.com" do
@@ -95,8 +107,8 @@ CA Certificate only, for verification:
       cacertificate "/etc/myca.pem"
     end
 
-Retrieve the CRL for a CA. The resource name specified must match the 
---ca-name parameter used when running `chef-ssl gencrl`. Ideally we'd use the 
+Retrieve the CRL for a CA. The resource name specified must match the
+--ca-name parameter used when running `chef-ssl gencrl`. Ideally we'd use the
 DN of the CA but the format wreaks havoc on chef searches:
 
     x509_crl "My-CA" do
@@ -107,8 +119,8 @@ If you want you specify a path for the CRL file. However due to some oddities wi
 OpenVPN (and thus likely openssl) that are not fully documented, to function properly the
 CRL must be saved as /etc/ssl/certs/<hash>.r0 where the hash is that of the CA. The x509_crl
 provider by default does the hash generation and puts it in the correct place. If you need
-to find the the file to specify in another recipy, use the x509_get_crl_path() method 
-(defined in x509/libraries/x509.rb) and it will return the fully qualified path to the CRL. For 
+to find the the file to specify in another recipy, use the x509_get_crl_path() method
+(defined in x509/libraries/x509.rb) and it will return the fully qualified path to the CRL. For
 example:
 
     crl_path = x509_get_crl_path("My-CA")
@@ -206,12 +218,12 @@ Revoking Certificates
 A few notes about revoking certificates. This is a two step process on purpose. Some background:
 
  * There is no API in openssl to revoke certificates. It is done using the "openssl ca -revoke" command line.
- * To revoke a certificate you need the CA passphrase. Storing this insecurely is a horrible idea. 
+ * To revoke a certificate you need the CA passphrase. Storing this insecurely is a horrible idea.
  * The author had a requirement to support marking certificates as 'revoked' using tools other than chef-ssl (ie: python) but maintaining the workflow.
 
 So the two steps are:
 
-1) Using `chef-ssl revoke`, move the certificate from the "certificates" data bag to the "revoked\_certificates" data bag, adding "revoked: false", "serial" set with the certificate's serial number (in decimal) and "revoked\_date" with the current date/time. Other recipes, if required, can pull the list of revoked certificates and store them locally to reject new incoming connections as needed (ie: OpenVPN etc which supports a directory of decimal serial numbers as of v2.3, etc). This movement of the certificate data bag item can be easily emulated by other languages as well. 
+1) Using `chef-ssl revoke`, move the certificate from the "certificates" data bag to the "revoked\_certificates" data bag, adding "revoked: false", "serial" set with the certificate's serial number (in decimal) and "revoked\_date" with the current date/time. Other recipes, if required, can pull the list of revoked certificates and store them locally to reject new incoming connections as needed (ie: OpenVPN etc which supports a directory of decimal serial numbers as of v2.3, etc). This movement of the certificate data bag item can be easily emulated by other languages as well.
 
 2) Using `chef-ssl gencrl`, really revoke the certificates that are marked "revoked: false" using the openssl command, set "revoked: true" and add "revoked\_date\_v2" with the current date/time. Once that is done for any number of certificates, generate the CRL file using the `openssl ca -gencrl` command. Note that this command will generate the CRL for all revoked certificates including those revoked outside of the chef-ssl tool. For convenience the CRL file is uploaded to the `certificate_revocation_list` data bag.
 
@@ -262,7 +274,7 @@ A) If you've revoked it using `chef-ssl revoke oops.example.com` then you can re
 4. Upload the json file to the certificates data bag: `knife data bag from file certificates oops.example.com.json`
 5. Remove the item from the revoked data bag: `knife data bag delete revoked\_certificates 01234abc`
 
-If you've already run the `chef-ssl gencrl` command that certificate is beyond hope. Run chef-client again and the node should generate a new CSR. 
+If you've already run the `chef-ssl gencrl` command that certificate is beyond hope. Run chef-client again and the node should generate a new CSR.
 
 TESTING
 =======

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,3 +10,10 @@ default['x509']['city'] = 'London'
 default['x509']['organization'] = 'Example Ltd'
 default['x509']['department'] = 'Certificate Automation'
 default['x509']['email'] = 'x509-auto@example.com'
+
+default['x509']['tls_root'] = case node['platform_family']
+when 'rhel'
+  '/etc/pki/tls'
+else
+  '/etc/ssl'
+end

--- a/client-gem/lib/chef-ssl/client/request.rb
+++ b/client-gem/lib/chef-ssl/client/request.rb
@@ -30,10 +30,10 @@ module ChefSSL
         IssuedCertificate.new(self, cert)
       end
 
-      def self.create(key, type, options)
-        name = EaSSL::CertificateName.new(options)
-        csr  = EaSSL::SigningRequest.new(:name => name, :key => key)
-        self.new('localhost', { 'type' => type }, csr)
+      def self.create(options)
+        name = EaSSL::CertificateName.new(options[:name])
+        csr  = EaSSL::SigningRequest.new(options.update({ :name => name }))
+        self.new('localhost', { 'type' => options[:type] || 'server' }, csr)
       end
     end
   end

--- a/client-gem/lib/chef-ssl/client/version.rb
+++ b/client-gem/lib/chef-ssl/client/version.rb
@@ -1,5 +1,5 @@
 module ChefSSL
   class Client
-    VERSION = '1.2.0'
+    VERSION = '1.2.1'
   end
 end

--- a/client-gem/lib/chef-ssl/command.rb
+++ b/client-gem/lib/chef-ssl/command.rb
@@ -45,8 +45,6 @@ command :issue do |c|
     unless options.type == 'server' || options.type == 'client'
       raise "type must be server or client"
     end
-    
-    client = ChefSSL::Client.new
 
     authority = ChefSSL::Client.load_authority(
       :password => ask("Enter CA passphrase:  ") { |q| q.echo = false },
@@ -66,7 +64,7 @@ command :issue do |c|
       :email => h['emailAddress']
     }
 
-    req = ChefSSL::Client::Request.create(key, options.type, name)
+    req = ChefSSL::Client::Request.create(options.__hash__.update({ :key => key, :name => name }))
     digest = eval "OpenSSL::Digest::#{options.digest}.new"
     cert = authority.sign(req, digest)
 
@@ -82,7 +80,7 @@ command :issue do |c|
       end
       cert.req.host = options.host
       cert.save!
-    end 
+    end
 
     say "#{'Key:'.cyan}"
     say HighLine.color(key.private_key.to_s, :bright_black)
@@ -317,7 +315,7 @@ command :revoke do |c|
   c.action do |args, options|
     if args.size < 1
       say "Error, specify a HOSTNAME to revoke."
-    else 
+    else
       client = ChefSSL::Client.new
       args.each do |host|
         client.revoke_certificate(host)

--- a/client-gem/spec/request_spec.rb
+++ b/client-gem/spec/request_spec.rb
@@ -84,7 +84,7 @@ EOCERT
     name = {
       :common_name => 'cn'
     }
-    req = ChefSSL::Client::Request.create(key, 'server', name)
+    req = ChefSSL::Client::Request.create({ :name => name, :key => key, :type => 'server'})
     req.class.should == ChefSSL::Client::Request
   end
 

--- a/libraries/x509.rb
+++ b/libraries/x509.rb
@@ -13,7 +13,7 @@ def x509_load_key(path)
 end
 
 def x509_generate_csr(info)
-  digest = eval "OpenSSL::Digest::#{digest}.new"
+  digest = eval "OpenSSL::Digest::#{info[:digest]}.new"
   ea_name = EaSSL::CertificateName.new(info[:name])
   ea_csr  = EaSSL::SigningRequest.new(info.merge({:name => ea_name}))
   ea_csr

--- a/libraries/x509.rb
+++ b/libraries/x509.rb
@@ -12,10 +12,10 @@ def x509_load_key(path)
   return EaSSL::Key.load(path)
 end
 
-def x509_generate_csr(key, digest, name)
+def x509_generate_csr(info)
   digest = eval "OpenSSL::Digest::#{digest}.new"
-  ea_name = EaSSL::CertificateName.new(name)
-  ea_csr  = EaSSL::SigningRequest.new(:name => ea_name, :key => key, :digest => digest)
+  ea_name = EaSSL::CertificateName.new(info[:name])
+  ea_csr  = EaSSL::SigningRequest.new(info.merge({:name => ea_name}))
   ea_csr
 end
 
@@ -65,7 +65,7 @@ end
 #private get a crl item for the CA specified from the data bag
 def x509_get_crl(caname)
   # search for CRL in one of its issued certificate databags
-  items = search('certificate_revocation_list', "ca:#{caname}") 
+  items = search('certificate_revocation_list', "ca:#{caname}")
   if items.nil? or items.size == 0
     raise "Could not find CRL for CA '#{caname}'"
   elsif items.size > 1
@@ -75,7 +75,7 @@ def x509_get_crl(caname)
 end
 
 #for a caname in the certificate_revocation_list data bag, return the path to the file
-def x509_get_crl_path(caname) 
+def x509_get_crl_path(caname)
   item = x509_get_crl(caname)
-  return "/etc/ssl/certs/#{item['hash']}.r0"  
+  return ::File.join(node['x509']['tls_root'], 'certs', "#{item['hash']}}.r0")
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email "dev@arcticwolf.com"
 license          "Apache"
 description      "Deploy a Chef-managed Certificate Authority"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.2.0"
+version          "1.2.1"
 
 depends 'vt-gpg'

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -57,7 +57,7 @@ action :create do
           f.content certbag['certificate']
         end
         f.action :create
-        
+
         if new_resource.cacertificate && certbag['cacert']
           f = resource("file[#{new_resource.cacertificate}]")
           f.content certbag['cacert']
@@ -90,17 +90,19 @@ action :create do
         end
 
         # Generate the new CSR using the existing key
-        csr = x509_generate_csr(
-          key,
-          new_resource.digest,
-          :common_name => new_resource.cn || new_resource.name,
-          :city => node['x509']['city'],
-          :state => node['x509']['state'],
-          :email => node['x509']['email'],
-          :country => node['x509']['country'],
-          :department => node['x509']['department'],
-          :organization => node['x509']['organization']
-        )
+        csr = x509_generate_csr({
+          :key => key,
+          :name => {
+            :common_name => new_resource.cn || new_resource.name,
+            :city => node['x509']['city'],
+            :state => node['x509']['state'],
+            :email => node['x509']['email'],
+            :country => node['x509']['country'],
+            :department => node['x509']['department'],
+            :organization => node['x509']['organization']
+          },
+          :subject_alt_name => new_resource.subject_alt_name
+        })
         cert = nil
       else
         # Generate and encrypt the private key with the public key of
@@ -115,16 +117,19 @@ action :create do
 
         # Generate the CSR, and sign it with a scratch CA to create a
         # temporary certificate.
-        csr = x509_generate_csr(key,
-          new_resource.digest,
-          :common_name => new_resource.cn || new_resource.name,
-          :city => node['x509']['city'],
-          :state => node['x509']['state'],
-          :email => node['x509']['email'],
-          :country => node['x509']['country'],
-          :department => node['x509']['department'],
-          :organization => node['x509']['organization']
-        )
+        csr = x509_generate_csr({
+          :key => key,
+          :name => {
+            :common_name => new_resource.cn || new_resource.name,
+            :city => node['x509']['city'],
+            :state => node['x509']['state'],
+            :email => node['x509']['email'],
+            :country => node['x509']['country'],
+            :department => node['x509']['department'],
+            :organization => node['x509']['organization']
+          },
+          :subject_alt_name => new_resource.subject_alt_name
+        })
         cert, ca = x509_issue_self_signed_cert(
           csr,
           new_resource.type,

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -90,8 +90,9 @@ action :create do
         end
 
         # Generate the new CSR using the existing key
-        csr = x509_generate_csr({
+        info = {
           :key => key,
+          :digest => new_resource.digest,
           :name => {
             :common_name => new_resource.cn || new_resource.name,
             :city => node['x509']['city'],
@@ -100,9 +101,14 @@ action :create do
             :country => node['x509']['country'],
             :department => node['x509']['department'],
             :organization => node['x509']['organization']
-          },
-          :subject_alt_name => new_resource.subject_alt_name
-        })
+          }
+        }
+
+        if !new_resource.subject_alt_name.empty?
+          info[:subject_alt_name] = new_resource.subject_alt_name
+        end
+
+        csr = x509_generate_csr(info)
         cert = nil
       else
         # Generate and encrypt the private key with the public key of
@@ -117,8 +123,9 @@ action :create do
 
         # Generate the CSR, and sign it with a scratch CA to create a
         # temporary certificate.
-        csr = x509_generate_csr({
+        info = {
           :key => key,
+          :digest => new_resource.digest,
           :name => {
             :common_name => new_resource.cn || new_resource.name,
             :city => node['x509']['city'],
@@ -127,9 +134,14 @@ action :create do
             :country => node['x509']['country'],
             :department => node['x509']['department'],
             :organization => node['x509']['organization']
-          },
-          :subject_alt_name => new_resource.subject_alt_name
-        })
+          }
+        }
+
+        if !new_resource.subject_alt_name.empty?
+          info[:subject_alt_name] = new_resource.subject_alt_name
+        end
+
+        csr = x509_generate_csr(info)
         cert, ca = x509_issue_self_signed_cert(
           csr,
           new_resource.type,

--- a/providers/crl.rb
+++ b/providers/crl.rb
@@ -3,9 +3,9 @@ action :create do
   if not new_resource.filename.nil?
     crl_file = new_resource.filename
   else
-    crl_file = "/etc/ssl/certs/#{item['hash']}.r0"
+    crl_file = ::File.join(node['x509']['tls_root'], 'certs', "#{item['hash']}}.r0")
   end
-  Chef::Log.info("MDH: filename: #{crl_file}")
+  Chef::Log.info("CRL filename: #{crl_file}")
   new_resource.filename = crl_file
   file crl_file do
     content item['crl']

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -12,6 +12,7 @@ attribute :type, :kind_of => String, :default => 'server', :equal_to => ['server
 attribute :bits, :kind_of => Fixnum, :default => 2048, :equal_to => [1024, 2048, 4096, 8192]
 attribute :days, :kind_of => Fixnum, :default => (365 * 5)
 attribute :digest, :kind_of => String, :default => 'SHA256', :equal_to => ['SHA', 'SHA1', 'SHA224', 'SHA256', 'SHA384', 'SHA512', 'MD5']
+attribute :subject_alt_name, :kind_of => Array, :default => Array.new
 
 attribute :owner, :kind_of => String, :default => 'root'
 attribute :group, :kind_of => String, :default => 'root'


### PR DESCRIPTION
From https://github.com/rtkwlf/chef-x509/pull/3. 

Includes original changes, as well as:
- rspec test for subjectAltName presence in CSR options
- example in documentation as to how to ask for a CSR (note: when you do this for use in a browser, you _must_ include the original CN in the subjectAltName field)
- adjust Chef info output to remove internal developer reference
- if subjectAltName is empty, don't include it in the CSR
- general `digest` fixes in tests and libraries to handle it as part of the `info` hash

All 17 rspec tests passed in clean local environment.
