### PR TITLE
Added peer and custom node types, added custom extensions

### DIFF
--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -107,6 +107,10 @@ action :create do
         if !new_resource.subject_alt_name.empty?
           info[:subject_alt_name] = new_resource.subject_alt_name
         end
+        
+        if !new_resource.extensions.empty?
+          info[:extensions] = new_resource.extensions
+        end
 
         csr = x509_generate_csr(info)
         cert = nil
@@ -139,6 +143,10 @@ action :create do
 
         if !new_resource.subject_alt_name.empty?
           info[:subject_alt_name] = new_resource.subject_alt_name
+        end
+
+        if !new_resource.extensions.empty?
+          info[:extensions] = new_resource.extensions
         end
 
         csr = x509_generate_csr(info)

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -8,11 +8,12 @@ end
 attribute :name, :kind_of => String, :name_attribute => true
 attribute :cn,   :kind_of => String
 attribute :ca,   :kind_of => String, :required => true
-attribute :type, :kind_of => String, :default => 'server', :equal_to => ['server', 'client']
+attribute :type, :kind_of => String, :default => 'server', :equal_to => ['server', 'client', 'peer', 'custom']
 attribute :bits, :kind_of => Fixnum, :default => 2048, :equal_to => [1024, 2048, 4096, 8192]
 attribute :days, :kind_of => Fixnum, :default => (365 * 5)
 attribute :digest, :kind_of => String, :default => 'SHA256', :equal_to => ['SHA', 'SHA1', 'SHA224', 'SHA256', 'SHA384', 'SHA512', 'MD5']
 attribute :subject_alt_name, :kind_of => Array, :default => Array.new
+attribute :extensions, :kind_of => Array, :default => Array.new
 
 attribute :owner, :kind_of => String, :default => 'root'
 attribute :group, :kind_of => String, :default => 'root'


### PR DESCRIPTION
Added peer type which requests for serverAuth+clientAuth cert
Added custom type where user can specify the needed extensions

All this stuff is not yet accepted to the EaSSL3 master, it is proposed in the [https://github.com/bellpeterm/eassl/pull/5].
