### PR TITLE
Touch a file when certificate expiry approaches

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ DN components to use when creating certificate names:
  * `node['x509']['department']`
  * `node['x509']['email']`
 
+When a certificate is with `node['x509']['cert_expiry_upcoming_alert_days']`
+days of expiring the 'certificate' provider will touch the file path at `node['x509']['cert_expiry_upcoming_flag']`.
+
 Usage
 =====
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,3 +17,6 @@ when 'rhel'
 else
   '/etc/ssl'
 end
+
+default['x509']['cert_expiry_upcoming_flag'] = '/var/run/cert_expiry_upcoming.flag'
+default['x509']['cert_expiry_upcoming_alert_days'] = 30

--- a/libraries/x509.rb
+++ b/libraries/x509.rb
@@ -79,3 +79,13 @@ def x509_get_crl_path(caname)
   item = x509_get_crl(caname)
   return ::File.join(node['x509']['tls_root'], 'certs', "#{item['hash']}.r0")
 end
+
+def x509_certificate_expiry_upcoming(cert_text, alert_days)
+  expiry = OpenSSL::X509::Certificate.new(cert_text).not_after
+  days_until_expiry = ((expiry - Time.now) / 86400).floor
+  Chef::Log.warn("Certificate expires in #{days_until_expiry} days at: #{expiry}")
+  if days_until_expiry < alert_days
+    return true
+  end
+  return false
+end


### PR DESCRIPTION
This change adds logic to touch a file under /var/run (configurable by
attribute) when expiry of the certificate is within a configured number
of days.
