### PR TITLE
Fix client SSL certificate and key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ See the chef-ssl program's embedded help text for options:
       -v, --version        Display version information
       -t, --trace          Display backtrace when an error occurs
 
+To build the client gem, run `gem build chef-ssl-client.gemspec` in the `client-gem` directory.
 
 Workflow
 ========

--- a/client-gem/Gemfile.lock
+++ b/client-gem/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    chef-ssl-client (1.2.0)
+    chef-ssl-client (1.2.3)
       activesupport (>= 3.1.0)
       chef (>= 0.10.0)
       commander (~> 4.1.0)

--- a/client-gem/chef-ssl-client.gemspec
+++ b/client-gem/chef-ssl-client.gemspec
@@ -7,11 +7,11 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc" ]
-  s.summary = "A command-line client the ssl cookbook's signing requirements"
+  s.summary = "A command-line client for the ssl cookbook's signing requirements"
   s.description = s.summary
-  s.author = "Venda"
-  s.email = "auto-ssl@venda.com"
-  s.homepage = "https://github.com/VendaTech/chef-cookbook-ssl"
+  s.author = "Arctic Wolf Networks"
+  s.email = "dev@arcticwolf.com"
+  s.homepage = "https://github.com/rtkwlf/chef-x509"
 
   s.add_dependency "chef",          ">= 0.10.0"
   s.add_dependency "spice",         "= 1.0.4"   # >= 1.0.6 brings breaking changes

--- a/client-gem/lib/chef-ssl/client.rb
+++ b/client-gem/lib/chef-ssl/client.rb
@@ -37,6 +37,17 @@ module ChefSSL
       else
         verify_mode = OpenSSL::SSL::VERIFY_PEER
       end
+      
+      # if an SSL client cert or key is present, they need to be passed to Spice (and Faraday) as OpenSSL objects
+      ssl_client_cert = ssl_client_key = nil
+      if Chef::Config.ssl_client_cert
+        raw_cert = File.read Chef::Config.ssl_client_cert
+        ssl_client_cert = OpenSSL::X509::Certificate.new raw_cert
+      end
+      if Chef::Config.ssl_client_key
+        raw_key = File.read Chef::Config.ssl_client_key
+        ssl_client_key = OpenSSL::PKey.read raw_key
+      end
 
       Spice.setup do |s|
         s.server_url = chef_server_url
@@ -45,8 +56,8 @@ module ChefSSL
         s.connection_options = {
           :ssl => {
             :verify_mode => verify_mode,
-            :client_cert => Chef::Config.ssl_client_cert,
-            :client_key => Chef::Config.ssl_client_key,
+            :client_cert => ssl_client_cert,
+            :client_key => ssl_client_key,
             :ca_path => Chef::Config.ssl_ca_path,
             :ca_file => Chef::Config.ssl_ca_file,
           }

--- a/client-gem/lib/chef-ssl/client/version.rb
+++ b/client-gem/lib/chef-ssl/client/version.rb
@@ -1,5 +1,5 @@
 module ChefSSL
   class Client
-    VERSION = '1.2.1'
+    VERSION = '1.2.3'
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email "dev@arcticwolf.com"
 license          "Apache"
 description      "Deploy a Chef-managed Certificate Authority"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.2.2"
+version          "1.2.3"
 
 depends 'vt-gpg'


### PR DESCRIPTION
When a client SSL certificate and key are defined in the Chef configuration, the contents of the files need to be read and passed to Spice's connection_options hash as OpenSSL objects (X509::Certificate and PKey).

Bumped the client gem version and cookbook version to 1.2.3 to reflect this change (since the client was still at 1.2.1 but the cookbook was 1.2.2) and updated some URLs and documentation.
