### PR TITLE
Fix the ca_search

### DIFF
--- a/client-gem/lib/chef-ssl/client.rb
+++ b/client-gem/lib/chef-ssl/client.rb
@@ -73,11 +73,7 @@ module ChefSSL
     end
 
     def ca_search(ca=nil)
-      if ca
-        nodes = Spice.nodes("csr_outbox_*_ca:#{ca}")
-      else
-        nodes = Spice.nodes("csr_outbox_*")
-      end
+      nodes = Spice.nodes("csr_outbox_*")
       nodes.each do |node|
         next if node.normal['csr_outbox'].nil?
         node.normal['csr_outbox'].each do |id, data|


### PR DESCRIPTION
The search by ca is used for autosign, and it is broken in
that it returns every single node out there, which breaks
when there's more than 1000 nodes due to paging problems.

Testing: made this change on certwolf when it stopped finding nodes.